### PR TITLE
Fix: Ensure GitHub issues are created in correct repository

### DIFF
--- a/.claude/ccpm.config
+++ b/.claude/ccpm.config
@@ -1,0 +1,58 @@
+#!/bin/bash
+# CCPM Configuration
+# This ensures all GitHub issues are created in the correct repository
+
+# Function to detect repository from git remote with enhanced error handling
+get_github_repo() {
+    local remote_url=$(git remote get-url origin 2>/dev/null)
+    
+    if [ -z "$remote_url" ]; then
+        echo "Error: No git remote found" >&2
+        return 1
+    fi
+    
+    # Handle both SSH and HTTPS, with or without .git extension
+    local repo=$(echo "$remote_url" | sed -E 's#^(https://|git@)github\.com[:/]##; s#\.git$##')
+    
+    # Validate format
+    if [[ ! "$repo" =~ ^[^/]+/[^/]+$ ]]; then
+        echo "Error: Invalid repository format: $repo" >&2
+        return 1
+    fi
+    
+    echo "$repo"
+}
+
+# Allow environment override
+if [ -n "$CCPM_GITHUB_REPO" ]; then
+    GITHUB_REPO="$CCPM_GITHUB_REPO"
+else
+    GITHUB_REPO=$(get_github_repo) || exit 1
+fi
+
+# Extract owner and repo name
+GITHUB_OWNER=$(echo $GITHUB_REPO | cut -d/ -f1)
+GITHUB_REPO_NAME=$(echo $GITHUB_REPO | cut -d/ -f2)
+
+# Export for gh CLI
+export GH_REPO="$GITHUB_REPO"
+
+# Validate repository exists (optional - can be disabled for performance)
+if [ "${CCPM_SKIP_REPO_VALIDATION:-false}" != "true" ]; then
+    if ! gh repo view "$GITHUB_REPO" >/dev/null 2>&1; then
+        echo "Warning: Repository $GITHUB_REPO not accessible. Please ensure:" >&2
+        echo "  1. Repository exists on GitHub" >&2
+        echo "  2. You have write access" >&2
+        echo "  3. You're authenticated with gh CLI (run: gh auth login)" >&2
+    fi
+fi
+
+# Wrapper function with error handling and logging
+gh_issue_create() {
+    echo "Creating issue in: $GITHUB_REPO" >&2
+    gh issue create --repo "$GITHUB_REPO" "$@"
+}
+
+# Export functions for use in other scripts
+export -f get_github_repo
+export -f gh_issue_create

--- a/.claude/commands/pm/epic-sync.md
+++ b/.claude/commands/pm/epic-sync.md
@@ -27,6 +27,13 @@ If no tasks found: "❌ No tasks to sync. Run: /pm:epic-decompose $ARGUMENTS"
 
 ### 1. Create Epic Issue
 
+#### First, detect the GitHub repository:
+```bash
+# Get the current repository from git remote
+REPO=$(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/' || echo "user/repo")
+echo "Creating issues in repository: $REPO"
+```
+
 Strip frontmatter and prepare GitHub issue body:
 ```bash
 # Extract content without frontmatter
@@ -80,6 +87,7 @@ fi
 
 # Create epic issue with labels
 epic_number=$(gh issue create \
+  --repo "$REPO" \
   --title "Epic: $ARGUMENTS" \
   --body-file /tmp/epic-body.md \
   --label "epic,epic:$ARGUMENTS,$epic_type" \
@@ -129,6 +137,7 @@ if [ "$task_count" -lt 5 ]; then
         --json number -q .number)
     else
       task_number=$(gh issue create \
+        --repo "$REPO" \
         --title "$task_name" \
         --body-file /tmp/task-body.md \
         --label "task,epic:$ARGUMENTS" \
@@ -154,7 +163,7 @@ if [ "$task_count" -ge 5 ]; then
   if gh extension list | grep -q "yahsan2/gh-sub-issue"; then
     subissue_cmd="gh sub-issue create --parent $epic_number"
   else
-    subissue_cmd="gh issue create"
+    subissue_cmd="gh issue create --repo \"$REPO\""
   fi
   
   # Batch tasks for parallel processing
@@ -183,7 +192,7 @@ Task:
          gh sub-issue create --parent $epic_number --title "$task_name" \
            --body-file /tmp/task-body.md --label "task,epic:$ARGUMENTS"
        - Otherwise: 
-         gh issue create --title "$task_name" --body-file /tmp/task-body.md \
+         gh issue create --repo "$REPO" --title "$task_name" --body-file /tmp/task-body.md \
            --label "task,epic:$ARGUMENTS"
     4. Record: task_file:issue_number
     

--- a/.claude/rules/github-operations.md
+++ b/.claude/rules/github-operations.md
@@ -19,7 +19,9 @@ gh issue view {number} --json state,title,labels,body
 
 ### Create Issue
 ```bash
-gh issue create --title "{title}" --body-file {file} --label "{labels}"
+# Always specify repo to avoid defaulting to wrong repository
+REPO=$(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
+gh issue create --repo "$REPO" --title "{title}" --body-file {file} --label "{labels}"
 ```
 
 ### Update Issue

--- a/.claude/rules/strip-frontmatter.md
+++ b/.claude/rules/strip-frontmatter.md
@@ -38,9 +38,10 @@ Always strip frontmatter when:
 # Bad - includes frontmatter
 gh issue create --body-file task.md
 
-# Good - strips frontmatter
+# Good - strips frontmatter and specifies repo
+REPO=$(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
 sed '1,/^---$/d; 1,/^---$/d' task.md > /tmp/clean.md
-gh issue create --body-file /tmp/clean.md
+gh issue create --repo "$REPO" --body-file /tmp/clean.md
 ```
 
 ### Posting a comment


### PR DESCRIPTION
- Add explicit --repo flag to all gh issue create commands
- Create repository detection configuration file
- Handle both SSH and HTTPS git remote formats
- Add validation and error handling for repository detection

This prevents issues from being created in automazeio/ccpm instead of the user's actual repository.